### PR TITLE
Boostrap for the Homepage including Posts Preview partial, Bootstrap and CSS further Configured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem 'bootstrap', '~> 5.3.2'
+gem "cssbundling-rails", "~> 1.4"
 
 gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
+    cssbundling-rails (1.4.0)
+      railties (>= 6.0.0)
     date (3.3.4)
     debug (1.9.0)
       irb (~> 1.10)
@@ -258,6 +260,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3.2)
   capybara
+  cssbundling-rails (~> 1.4)
   debug
   importmap-rails
   jbuilder

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
  *= require_tree .
  *= require_self
  */
+ @import "bootstrap";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,15 +6,12 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
     <p>Welcome to Blog by Conan</p>
-    <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
-    </main>
   </body>
 </html>

--- a/app/views/pages/_post_previews.html.erb
+++ b/app/views/pages/_post_previews.html.erb
@@ -1,0 +1,7 @@
+<div class="post" style="width: 18rem;">
+  <div class="post-body">
+    <h5 class="post-title">Bootstrap</h5>
+    <p class="post-text">This is an example Blog post, click below to explore this post further</p>
+    <a href="#" class="btn btn-primary">View the full Post</a>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,1 +1,48 @@
 <h1>Homepage</h1>
+
+<nav class="navbar navbar-expand-lg bg-light">
+  <div class="container-fluid">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="#">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">Latest Blog Post</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">Archive</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link disabled">Not Available</a>
+        </li>
+      </ul>
+    </div>
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="#">Active</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">Featured Blog Posts</a>
+        <ul class="dropdown-menu">
+          <li><a class="dropdown-item" href="#">Example 1</a></li>
+          <li><a class="dropdown-item" href="#">Example 2</a></li>
+          <li><a class="dropdown-item" href="#">Example 3</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item" href="#">Example 4</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#">About the Blog</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link disabled">Not Available</a>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<%= render partial: "pages/post_previews" %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "bootstrap", to: "bootstrap.min.js", preload: true
+pin "@popperjs/core", to: "popper.js", preload: true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,4 +9,4 @@ Rails.application.config.assets.version = "1.0"
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "blog",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Homepage now contains several Boostrap features including a Navbar with standard navbar buttons and navbar pills also to implement a left and right navbar. Posts Previews partial made to handle Bootstrap elements in the homepage (just the homepage initially), including first version of Post similar to a Bootstrap card appearance in the views.

Will update href links with link_to in the next commit.

Added cssbundling-rails gem for compatibility with Bootstrap.

Converted css into scss for better compatibility with Bootstrap and future CSS, such as the folders for components and pages created.

Altered Rails assets file for handling Bootstrap.

Package.json file added.