### PR TITLE
Routes Fix for New Post form to Display, and Index Path Adjustment

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -34,7 +34,7 @@
       <li class="nav-item">
         <li><a class="nav-link" <%= link_to 'Create New Post', new_post_path %></a></li>
         <li><a class="nav-link" <%= link_to "About the Blog", about_path %></a></li>
-        <li><a class="nav-link" <%= link_to "Blog Index", posts_path %></a></li>
+        <li><a class="nav-link" <%= link_to "Blog Index", index_path %></a></li>
       <li class="nav-item">
         <a class="nav-link disabled">Not Available</a>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
+  resources :posts
+
   root 'pages#home', as: 'home'
 
   get 'about', to: 'pages#about', as: :about
@@ -16,7 +18,5 @@ Rails.application.routes.draw do
 
   get 'posts/:id', to: 'posts#show'
 
-  post '/posts', to: 'posts#create'
-  
   resources :posts
 end


### PR DESCRIPTION
Put the resources for posts higher in the routes file, now it is called before the individual posts routes and therefore the form to create a new post appears when "Create New Post" link is clicked on the homepage navbar.
Before the link was taking the user through to an already created post page.

Blog Index link now has an index_path so it is correctly assigned going forward.