### PR TITLE
Last Post Created Setup, Turbo Stream, and Additional Posts can be Created after New Post Created

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,9 +7,9 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     if @post.save
-      redirect_to @post
+      redirect_to new_post_path, notice: "Post was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new
     end
   end
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,15 +1,17 @@
-<%= simple_form_for @post do |f| %>
-  <%= f.input :title %>
-  <%= f.input :body, as: :text %>
-  <%= f.submit %>
-  <% if @post.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
-      <ul>
-      <% @post.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
+<turbo-frame id="posts">
+  <%= simple_form_for @post do |f| %>
+    <%= f.input :title %>
+    <%= f.input :body, as: :text %>
+    <%= f.submit "Create Post" %>
+    <% if @post.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
+        <ul>
+        <% @post.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</turbo-frame>

--- a/app/views/posts/create.tubo_stream.erb
+++ b/app/views/posts/create.tubo_stream.erb
@@ -1,0 +1,6 @@
+<turbo-stream action="append" target="posts">
+  <template>
+    <li><%= @post.title %></li>
+    <li><%= @post.content %></li>
+  </template>
+</turbo-stream>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,7 @@
 <ul>
   <% @posts.each do |post| %>
     <li><%= post.title %></li>
+    <li><%= post.body %></li>
   <% end %>
 </ul>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,11 +1,13 @@
-<div class="container">
-  <%= link_to sanitize("&larr; Back to posts"), index_path %>
+<div class="container mx-auto">
+  <%= link_to sanitize("&larr; Posts Index"), index_path, class: "text-blue-500 hover:underline" %>
 
-   <div class="header">
-    <h1>New post</h1>
+   <div class="header mt-6">
+    <h1 class="text-2xl font-semibold">Last created post</h1>
+    <ul class="mt-4">
+      <li class="mb-2"><%= Post.last.title %></li>
+      <li><%= Post.last.body %></li>
+    </ul>
    </div>
 
-  <%= turbo_frame_tag "first_turbo_frame" do %>
-    <%= render 'form' %>
-  <% end %>
+   <%= render 'form' %>
 </div>


### PR DESCRIPTION
Added terminology to see the latest blog post on the page to create a new blog post above the new create blog post form. Also, both the title and the body of the last post will appear meaning the placeholder text has been replaced.

Added the new post creation form to the new post page to allow the user create another blog post, this was added due to the homepage navbar link only linking to the last post created, therefore the ability to create another new blog post was not available. If another blog post is created, this will replace the last created blog post rather than a growing list of new blog post titles and bodies.

Added flash notice to posts controller to confirm when a new post has been created to the user, will added a partial in the future for this flash notice also.

Created a Turbo Stream create page to handle new posts being created, and also added Turbo Stream to the Simple form partial for a new blog post.

Tailwind styling added to new post page to differentiate the text in the page from each other.

The posts index page now also has the body of each blog post visible, together with the previously added blog post titles.

Next commit (whether within this or another branch) will contain the 422 , status: :unprocessable_entity error message again in the posts controller.