### PR TITLE
Tailwind Cards for Blog Posts, Posts Index Reordered

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,12 +1,16 @@
-<ul>
-  <% @posts.each do |post| %>
-    <li><%= post.title %></li>
-    <li><%= post.body %></li>
-  <% end %>
-</ul>
-
 <div class="container">
-  <p>Enjoy this Video while choosing a Blog Post to View</p>
-  <embed type="video/webm" width="250" height="200" />
+  <div class="video">
+    <p>Enjoy this Video while choosing a Blog Post to View</p>
+    <embed type="video/webm" width="250" height="200" />
+  </div>
+  <div class="card">
+    <% @posts.each do |post| %>
+      <div class="max-w-sm rounded overflow-hidden shadow-lg">
+        <div class="px-6 py-4">
+          <h1 class="text-2xl font-semibold text-gray-700"><%= post.title %></h1>
+          <p class="text-xl font-light leading-relaxed text-gray-400 mt-5"><%= post.body %></p>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
Created classes for both the video (eventually will put this in), and the individual blog posts. Removed list format for the title and body, better designed like this with the title as the h1 header and the p text as the post body.

Tailwind code implemented for cards within the index page. For each element (each of the text elements for the title and body of posts) there is individualised Tailwind styling.

This is the first step towards creating a presentable card for a blog post, there are issues such as cards being created above the first blog post record, and them being too wide (could be other factors such as not having long enough blog posts however).