### PR TITLE
Bootstrap Flash Notice Created for Post Creations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :info, :error, :success
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,8 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     if @post.save
-      redirect_to new_post_path, notice: "Post was successfully created."
+      flash[:notice] = 'Post successfully created.'
+      redirect_to new_post_path
     else
       render :new
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,5 +18,7 @@
         <%= yield %>
       </main>
       <%= render partial: 'shared/footer' %>
+
+      <%= render 'shared/flashes' %>
   </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,20 +3,28 @@
     <%= f.input :title %>
     <%= f.input :body, as: :text %>
     <%= f.submit "Create Post" %>
-    <% if @post.errors.any? %>
-      <div id="error_explanation">
-        <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
-        <ul>
-        <% @post.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-        </ul>
+  <% end %>
+
+  <% if flash[:notice] %>
+    <div class="alert alert-info d-flex align-items-center" role="alert">
+      <svg class="bi flex-shrink-0 me-2" role="img" aria-label="Info:"><use xlink:href="#info-fill"/></svg>
+      <div>
+        <%= flash[:notice] %>
       </div>
-    <% end %>
+    </div>
+  <% end %>
+
+  <% if flash[:alert] %>
+    <div class="alert alert-warning d-flex align-items-center" role="alert">
+      <svg class="bi flex-shrink-0 me-2" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill"/></svg>
+      <div>
+        <%= flash[:alert] %>
+      </div>
+    </div>
   <% end %>
 </turbo-frame>
 
-<p> Below Form Select Element is for future styling of the Blog Post</p>
+<p>Below Form Select Element is for future styling of the Blog Post</p>
 <select class="form-select" aria-label="Default select example" disabled>
   <option selected>Choose a Blog Type</option>
   <option value="1">Small Post</option>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,13 +1,13 @@
 <div class="container mx-auto">
   <%= link_to sanitize("&larr; Posts Index"), index_path, class: "text-blue-500 hover:underline" %>
 
-   <div class="header mt-6">
+  <div class="header mt-6">
     <h1 class="text-2xl font-semibold">Last created post</h1>
     <ul class="mt-4">
       <li class="mb-2"><%= Post.last.title %></li>
       <li><%= Post.last.body %></li>
     </ul>
-   </div>
+  </div>
 
-   <%= render 'form' %>
+  <%= render 'form' %>
 </div>


### PR DESCRIPTION
When a Blog Post is created, a flash message will appear confirming the outcome of the create post action, originally during the early part of this implementation it was occurring upon the page reload, however, after inserting the flash notice code inside the form partial and the Turbo Frame, it is now doing the flash notice message upon the exact action of clicking "Create Post".

The notices have Bootstrap styling added to them to stand out from the standardised Rails format of flash notices while still appearing in sync with the style of the Bootstrap and Tailwind already existing within the application.

Updated the application and posts controller for handling the flash notices, the post creation can handle the info, success and error messages that are then outputted to the user dependent upon the success or failure of the post creation. I will look to implement an error notice in a future commit on this branch.

This commit also contains a few code formatting tweaks to the new post page, nothing too major changed.

I have also included a flashes partial that is render in the application.html.erb layout file, I will look to also utilise this in a future commit, more than likely to move the view flash notice code into this partial along with the new flash error notice. 