### PR TITLE
Bootstrap Modal For Creating Blog Posts Setup, Ruby Version Tweak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby file: ".ruby-version"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,4 +284,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.12
+   2.5.6

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,10 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+// For Bootstrap Modals
+import "@popperjs/core"
+import "bootstrap"
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+export default class extends Controller {
+  connect() {
+    this.modal = new Modal(this.element)
+    this.modal.show()
+  }
+
+  hideBeforeRender(event) {
+    if (this.isOpen()) {
+      event.preventDefault()
+      this.element.addEventListener('hidden.bs.modal', event.detail.resume)
+      this.modal.hide()
+    }
+  }
+
+  isOpen() {
+    return this.element.classList.contains("show")
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,8 @@
     </h1>
      <main class="container mx-48 mt-64 max-w-5xl px-2 sm:px-6 lg:px-4">
         <%= yield %>
+        <%= turbo_frame_tag "modal", target: "_top" %>
       </main>
       <%= render partial: 'shared/footer' %>
-
-      <%= render 'shared/flashes' %>
   </body>
 </html>

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag "modal" do %>
+   <div class="modal fade" id="createPostModal" tabindex="-1" aria-labelledby="newPostModalLabel" aria-hidden="true" data-controller="modal" data-action="turbo:before-render@document->modal#hideBeforeRender">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content" id="modal_content">
+                <div class="modal-header">
+                    <h4 class="modal-title" id="newPostModalLabel"><%= title %></h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+
+                <div class="modal-body " id="modal_body">
+                    <%= yield %>
+                </div>
+            </div>
+        </div>
+    </div>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,4 +19,6 @@
   </p>
 
   <a class="btn btn-primary disabled placeholder col-4" aria-disabled="true"></a>
+
+  <%= link_to "New Blog Post", new_post_path, class: "btn btn-primary", data: { turbo_frame: "modal" }%>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -9,5 +9,7 @@
     </ul>
   </div>
 
-  <%= render 'form' %>
+  <%= render "modal", title: "New post" do %>
+    <%= render "form", post: @post %>
+  <% end %>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,5 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
-pin "bootstrap", to: "bootstrap.min.js", preload: true
-pin "@popperjs/core", to: "popper.js", preload: true
+pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.3.2/dist/js/bootstrap.esm.js"
+pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.8/lib/index.js"


### PR DESCRIPTION
Bootstrap modal has been added to the posts index page and opens automatically on the posts new page.

Added Bootstrap and Popper Core via a command line "./bin/importmap pin bootstrap" command. Subsequently added import for Popper Core and Bootstrap to the application.js file to ensure the modals and future modals are and will be working efficiently.

Posts are created via the input of text and Create Post submit field as before in the previous standard form in the Posts/New view.

Implemented a JS Modal controller to handle the connection to and appearance of a modal.

Implemented Turbo in the modal and view pages to ensure it is quick to appear.

Also separately to the modal work in this branch and commit, I have updated the Gemfile to read the Ruby version directly from the .ruby-version file. Along with an update to RubyGems to bump the version up to 2.5.6.