### PR TITLE
Modal Improvement and Planning for Further Modal Work

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -13,9 +13,32 @@ export default class extends Controller {
       this.element.addEventListener('hidden.bs.modal', event.detail.resume)
       this.modal.hide()
     }
+    this.element.classList.remove("fade-in")
+    this.element.classList.add("fade-out")
   }
 
   isOpen() {
     return this.element.classList.contains("show")
+  }
+
+
+  close() {
+    this.element.classList.remove("fade-in")
+    this.element.classList.add("fade-out")
+    setTimeout(() => {
+      this.element.remove()
+    }, 300)
+  }
+
+  handleKeyup(e) {
+    if (e.code == "Escape") {
+      this.close()
+    }
+  }
+
+  handleSubmit = (e) => {
+    if (e.detail.success) {
+      this.close()
+    }
   }
 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,7 +2,7 @@
   <%= simple_form_for @post do |f| %>
     <%= f.input :title %>
     <%= f.input :body, as: :text %>
-    <%= f.submit "Create Post" %>
+    <button type="submit" class="btn btn-primary">Create Post</button>
   <% end %>
 
   <% if flash[:notice] %>

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -1,14 +1,22 @@
-<%= turbo_frame_tag "modal" do %>
-   <div class="modal fade" id="createPostModal" tabindex="-1" aria-labelledby="newPostModalLabel" aria-hidden="true" data-controller="modal" data-action="turbo:before-render@document->modal#hideBeforeRender">
+<%= turbo_frame_tag "modal", class: "fade-in fade-out" do %>
+   <div class="modal fade" id="createPostModal"  class="fixed z-10 inset-0 overflow-y-auto" tabindex="-1" aria-labelledby="newPostModalLabel" aria-hidden="true" data-controller="modal" data-action="turbo:before-render@document->modal#hideBeforeRender">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content" id="modal_content">
                 <div class="modal-header">
                     <h4 class="modal-title" id="newPostModalLabel"><%= title %></h4>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                       <span aria-hidden="true">&times;</span>
+                    </button>
                 </div>
 
                 <div class="modal-body " id="modal_body">
                     <%= yield %>
+                </div>
+                <div class="modal-footer">
+                  <%= turbo_frame_tag "modal-footer" do %>
+                    <button type="button" class="btn btn-secondary"> <%= link_to "Homepage", home_path %> </button>
+                    <button type="button" class="btn btn-secondary" data-action="modal#close" aria-label="Close modal">Close</button>
+                  <% end %>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Modal closes when the Close button is clicked but does not fully link back to the new posts page and instead is in a static state. For now I have added an additional button link next to it to the blog homepage so it does not mean clicking a button leads to a dead end. Added Turbo frame tags for this to make it seamless once working as the homepage link is currently leading to a JavaScript error.

Modal now fades in and out on opening and closing respectively. Added Tailwind class styling to the modal fade div class also to begin the inclusion of additional Tailwind inside the Bootstrap modal.

Elements added to the JavaScript Modal controller including for the Escape key to exit the modal.

Create Post action converted from a Simple Form submit action to a button submit to improve its styling and appearance with the rest of the elements inside the modal.