### PR TITLE
Fix for Close and Homepage Boostrap Modal Buttons, Additional Modal tidy up

### DIFF
--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "modal", class: "fade-in fade-out" do %>
-   <div class="modal fade" id="createPostModal"  class="fixed z-10 inset-0 overflow-y-auto" tabindex="-1" aria-labelledby="newPostModalLabel" aria-hidden="true" data-controller="modal" data-action="turbo:before-render@document->modal#hideBeforeRender">
-        <div class="modal-dialog modal-dialog-centered" role="document">
+   <div class="modal fade fixed z-10 inset-0 overflow-y-auto" id="createPostModal" id="createPostModal"  tabindex="-1" aria-labelledby="newPostModalLabel" aria-hidden="true" data-controller="modal" data-action="turbo:before-render@document->modal#hideBeforeRender">
+        <div class="modal-dialog modal-dialog-centered" role="document" >
             <div class="modal-content" id="modal_content">
                 <div class="modal-header">
                     <h4 class="modal-title" id="newPostModalLabel"><%= title %></h4>
@@ -13,10 +13,8 @@
                     <%= yield %>
                 </div>
                 <div class="modal-footer">
-                  <%= turbo_frame_tag "modal-footer" do %>
-                    <button type="button" class="btn btn-secondary"> <%= link_to "Homepage", home_path %> </button>
-                    <button type="button" class="btn btn-secondary" data-action="modal#close" aria-label="Close modal">Close</button>
-                  <% end %>
+                    <button type="button" id="btnCloseCategories" class="btn btn-danger" data-bs-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary active" role="button" aria-pressed="true"><%= link_to "Homepage", home_path %></button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Combined the div class for the modal and the class styling on line 2 for the whole modal, now neater in appearance with it having a single div class rather than a div class and a separate class on the same line.

Reversed placement of Close and Homepage buttons in the new post page modal. Also removed the turbo frame tag and reimplemented a div class to replace it.

Added data-bs-dismiss replacing data-dismiss to the Close modal button to fix the incorrect response of only closing the modal and not enabling interactivity with the new post page when the button is clicked.

Updated the homepage button to have attributed to it several new elements, including role="button" aria-pressed="true" for making the button click to work for navigating to the homepage. I am still receiving an intermittent JavaScript content missing error so will keep this under investigation to fix going forward.