### PR TITLE
Improved Application Heading with tailwind

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,11 @@
   </head>
 
   <body>
-    <h1 class="text-3xl font-bold text-center text-blue-500">
-      <%= link_to "Blog by Conan", home_path %>
+  <div class="flex justify-center items-center">
+    <h1 class="text-5xl font-extrabold dark:text-white p-4 ">
+       <%= link_to "Blog by Conan", home_path %>
     </h1>
+  </div>
      <main class="container mx-48 mt-64 max-w-5xl px-2 sm:px-6 lg:px-4">
         <%= yield %>
         <%= turbo_frame_tag "modal", target: "_top" %>


### PR DESCRIPTION
Previous Application heading was too simplistic and generic in appearance.

Therefore, produced additional Tailwind, removed basic HTML styling and encapsulated the h1 title heading within a div class to give it uniqueness, Tailwind styling and padding so it does not appear stuck to the top of the webpage.

Will likely make additional changes to this in the future when the application's styling takes momentum.