### PR TITLE
pg_search gem and Search Functionality Setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem "sassc-rails"
 # For creating a new blog post
 gem "simple_form"
 
+# For searching for a blog post
+gem 'pg_search'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.4)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     popper_js (2.11.8)
     psych (5.1.1.1)
       stringio
@@ -268,6 +271,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
+  pg_search
   puma (>= 6.4.0)
   rails (~> 7.1.2)
   sassc-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,11 @@
 class PostsController < ApplicationController
 
   def index
-    @posts = Post.all
+    if params[:query].present?
+      @posts = Post.search_by_title(params[:query])
+    else
+      @posts = Post.all
+    end
   end
 
   def create

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,9 @@
 class Post < ApplicationRecord
+  include PgSearch::Model
+
+  pg_search_scope :search_by_title, against: :title
+  pg_search_scope :search_by_body, against: :body
+
   validates :title, presence: true
   validates :body, presence: true
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,6 +3,8 @@
     <p>Enjoy this Video while choosing a Blog Post to View</p>
     <embed type="video/webm" width="250" height="200" />
   </div>
+  <%= render partial: "shared/search_form" %>
+  <%= render 'shared/search_results', results: @results %>
   <div class="card">
     <% @posts.each do |post| %>
       <div class="max-w-sm rounded overflow-hidden shadow-lg">

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag posts_path, method: :get do %>
+  <%= text_field_tag(:query, params[:query], placeholder: 'Search posts...') %>
+  <%= submit_tag "Search" %>
+<% end %>

--- a/app/views/shared/_search_results.html.erb
+++ b/app/views/shared/_search_results.html.erb
@@ -1,0 +1,4 @@
+<% @posts.each do |post| %>
+  <h2><%= post.title %></h2>
+  <p><%= post.body %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,7 @@ Rails.application.routes.draw do
 
   get 'posts/:id', to: 'posts#show'
 
+  get '/posts/search', to: 'posts#search', as: 'posts_search'
+
   resources :posts
 end


### PR DESCRIPTION
Implemented pg-search gem, within the Postframework.

Reworked the posts controller index action to accommodate for the new search functionality.

Chosen to go with a search scope as opposed to the multi-search option that pg-search also caters for .

Rendered the search view functionality for the pg-search inside a new search form shared view partial. 

Also created a search results partial to handle rendering results dependent upon the entered search parameters, post title specific.

Created post search path route to handle the routing setup of the search functionality for searching for posts.

Tested in the Rails console, command "Post.search_by_title("Lorem")" returns one of the database seeds which contains the phrase "Lorem" in it. The same applies in the local Rails server.

The partials are rendered in the posts index page and will be revised to perform in other parts of the application too.