### PR TITLE
Additional Tailwind Design added to About page

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -13,7 +13,31 @@
   <p class="placeholder-glow">
     <span class="placeholder col-12"></span>
   </p>
-  <p>About Section Coming Soon...</p>
+  <section class="mx-auto max-w-screen-xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
+    <div class="max-w-3xl">
+      <h2 class="text-3xl font-bold sm:text-4xl text-center">
+        About the Blog
+      </h2>
+    </div>
+
+    <div class="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-16">
+      <div class="relative h-64 overflow-hidden sm:h-80 lg:h-full">
+        <img
+          alt=""
+          src="https://images.unsplash.com/reserve/LJIZlzHgQ7WPSh5KVTCB_Typewriter.jpg?q=80&w=1992&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+          class="absolute inset-0 h-full w-full object-cover"
+        />
+      </div>
+
+      <div class="lg:py-16 text-center">
+        <article class="space-y-4 text-gray-600">
+          <p>
+            Above is an image of how the blog is written.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
   <p class="placeholder-wave">
     <span class="placeholder col-12"></span>
   </p>


### PR DESCRIPTION
Replaced About page coming soon text with a new Tailwind About section that has a clean design with minimal clutter. 
Kept the placeholder Tailwind components as they are still appearing to be useful and relevant design components mixed in with the new Tailwind.

Text centered to emphasise the image between the two text elements.

Will build on this new Tailwind addition further as the blog progresses in development.

New About page image courtesy of: https://unsplash.com/photos/black-fayorit-typewriter-with-printer-paper-mk7D-4UCfmg